### PR TITLE
Consistent ValidationError type\rTESTING=unit

### DIFF
--- a/lib/promoted/ruby/client/errors.rb
+++ b/lib/promoted/ruby/client/errors.rb
@@ -1,42 +1,6 @@
 module Promoted
   module Ruby
     module Client
-      class RequestError < StandardError
-        def message
-          'Request.requestId should not be set'
-        end
-      end
-
-      class RequestInsertionError < StandardError
-        def message
-          'Do not set Request.insertion.  Set full_insertion.'
-        end
-      end
-
-      class InsertionRequestIdError < StandardError
-        def message
-          'Insertion.requestId should not be set'
-        end
-      end
-
-      class DeliveryScoreError < StandardError
-        def message
-          'Insertion.deliveryScore should not be set'
-        end
-      end
-
-      class InsertionIdError < StandardError
-        def message
-          'Insertion.insertionId should not be set'
-        end
-      end
-
-      class InsertionContentId < StandardError
-        def message
-          'Insertion.contentId should be set'
-        end
-      end
-
       class ShadowTrafficInsertionPageType < StandardError
         def message
           'Insertions must be unpaged when shadow traffic is on'

--- a/lib/promoted/ruby/client/validator.rb
+++ b/lib/promoted/ruby/client/validator.rb
@@ -139,13 +139,13 @@ module Promoted
             end
 
             def check_that_log_ids_not_set! req
-                raise RequestError if req.dig(:request, :request_id)
-                raise RequestInsertionError if req[:insertion]
+                raise ValidationError.new("Request.requestId should not be set") if req.dig(:request, :request_id)
+                raise ValidationError.new("Do not set Request.insertion.  Set full_insertion.") if req[:insertion]
       
                 req[:full_insertion].each do |insertion_hash|
-                  raise InsertionRequestIdError if insertion_hash[:request_id]
-                  raise InsertionIdError if insertion_hash[:insertion_id]
-                  raise DeliveryScoreError if insertion_hash[:delivery_score]
+                  raise ValidationError.new("Insertion.requestId should not be set") if insertion_hash[:request_id]
+                  raise ValidationError.new("'Insertion.insertionId should not be set") if insertion_hash[:insertion_id]
+                  raise ValidationError.new("Insertion.deliveryScore should not be set") if insertion_hash[:delivery_score]
                 end
               end      
         end

--- a/spec/promoted/ruby/client/validator_spec.rb
+++ b/spec/promoted/ruby/client/validator_spec.rb
@@ -207,25 +207,25 @@ RSpec.describe Promoted::Ruby::Client::Validator do
         it "should raise error for request_id" do
             dup_input = Marshal.load(Marshal.dump(input))
             dup_input[:request][:request_id] = SecureRandom.uuid
-            expect { @v.check_that_log_ids_not_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::RequestError)
+            expect { @v.check_that_log_ids_not_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /requestId should not be set/)
         end
     
         it "should raise error for request_id set in full_insertion" do
             dup_input = Marshal.load(Marshal.dump(input))
             dup_input[:full_insertion].first[:request_id] = SecureRandom.uuid
-            expect { @v.check_that_log_ids_not_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::InsertionRequestIdError)
+            expect { @v.check_that_log_ids_not_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /Insertion.requestId should not be set/)
         end
     
         it "should raise insertion_id error for insertion" do
             dup_input = Marshal.load(Marshal.dump(input))
             dup_input[:insertion] = []
-            expect { @v.check_that_log_ids_not_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::RequestInsertionError)
+            expect { @v.check_that_log_ids_not_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /Set full_insertion/)
         end
     
         it "should raise delivery_score error for insertion" do
             dup_input = Marshal.load(Marshal.dump(input))
             dup_input[:full_insertion].first[:delivery_score] = 5
-            expect { @v.check_that_log_ids_not_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::DeliveryScoreError)
+            expect { @v.check_that_log_ids_not_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /deliveryScore should not be set/)
         end
     end
 end


### PR DESCRIPTION
I'm more of the school that thinks having a separate error class per error makes it less likely that clients will handle correctly, so let's just have one common ValidationError.