### PR TITLE
Only parse JSON responses per content-type header\rTESTING=manual,unit

### DIFF
--- a/lib/promoted/ruby/client/faraday_http_client.rb
+++ b/lib/promoted/ruby/client/faraday_http_client.rb
@@ -23,7 +23,12 @@ module Promoted
                     req.body                    = request.to_json
                   end
         
-                  JSON.parse(response.body, :symbolize_names => true)
+                  norm_headers = response.headers.transform_keys(&:downcase)
+                  if norm_headers["content-type"] == "application/json"
+                    JSON.parse(response.body, :symbolize_names => true)
+                  else
+                    response.body
+                  end
             end
         end
       end

--- a/lib/promoted/ruby/client/faraday_http_client.rb
+++ b/lib/promoted/ruby/client/faraday_http_client.rb
@@ -24,7 +24,7 @@ module Promoted
                   end
         
                   norm_headers = response.headers.transform_keys(&:downcase)
-                  if norm_headers["content-type"] == "application/json"
+                  if norm_headers["content-type"] != nil && norm_headers["content-type"].start_with?("application/json")
                     JSON.parse(response.body, :symbolize_names => true)
                   else
                     response.body


### PR DESCRIPTION
Previously an empty or plain-text response would have thrown an error.