### PR TITLE
Only log error when page type wrong with shadow traffic\rTESTING=unit

### DIFF
--- a/lib/promoted/ruby/client.rb
+++ b/lib/promoted/ruby/client.rb
@@ -171,17 +171,19 @@ module Promoted
           # Note: This method expects as JSON (string keys) but internally, RequestBuilder
           # transforms and works with symbol keys.
           log_request_builder.set_request_params(args)
+          shadow_traffic_err = false
           if @perform_checks
             perform_common_checks! args
 
             if @shadow_traffic_delivery_percent > 0 && args[:insertion_page_type] != Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'] then
-              raise ShadowTrafficInsertionPageType
+              shadow_traffic_err = true
+              @logger.error(ShadowTrafficInsertionPageType.new) if @logger
             end
           end
           
           pre_delivery_fillin_fields log_request_builder
 
-          if should_send_as_shadow_traffic?
+          if !shadow_traffic_err && should_send_as_shadow_traffic?
             deliver_shadow_traffic args, headers
           end
 

--- a/spec/promoted/ruby/client_spec.rb
+++ b/spec/promoted/ruby/client_spec.rb
@@ -141,19 +141,19 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       input_with_unpaged
     end
 
-    it "throws if shadow traffic is on and request is prepaged" do
+    it "does not throw if shadow traffic is on and request is prepaged" do
       dup_input                       = Hash[input]
       dup_input["insertion_page_type"] = Promoted::Ruby::Client::INSERTION_PAGING_TYPE['PRE_PAGED']
 
       client = described_class.new(ENDPOINTS.merge({ :shadow_traffic_delivery_percent => 1.0 }))
       expect(client).not_to receive(:send_request)
-      expect { client.prepare_for_logging(dup_input) }.to raise_error(Promoted::Ruby::Client::ShadowTrafficInsertionPageType)
+      expect { client.prepare_for_logging(dup_input) }.not_to raise_error
     end
 
-    it "throws if shadow traffic is on and request paging type is undefined" do
+    it "does not throw if shadow traffic is on and request paging type is undefined" do
       client = described_class.new(ENDPOINTS.merge({ :shadow_traffic_delivery_percent => 1.0 }))
       expect(client).not_to receive(:send_request)
-      expect { client.prepare_for_logging(input) }.to raise_error(Promoted::Ruby::Client::ShadowTrafficInsertionPageType)
+      expect { client.prepare_for_logging(input) }.not_to raise_error
     end
 
     it "paging type is not checked when perform checks is off" do


### PR DESCRIPTION
Testing this, it occurred to me that we probably don't want to crash out of prepare_for_logging when the shadow traffic page type is wrong. So I changed it to log for now.