### PR TITLE
Allow separate api keys and add mock client tests\rTESTING=unit

### DIFF
--- a/lib/promoted/ruby/client.rb
+++ b/lib/promoted/ruby/client.rb
@@ -16,7 +16,7 @@ module Promoted
         class Error < StandardError; end
 
         attr_reader :perform_checks, :default_only_log, :delivery_timeout_millis, :metrics_timeout_millis, :should_apply_treatment_func,
-                    :default_request_headers
+                    :default_request_headers, :http_client
         
         # A common compact method implementation.
         def self.copy_and_remove_properties
@@ -36,7 +36,8 @@ module Promoted
           @logger = params[:logger] # Example:  Logger.new(STDERR, :progname => "promotedai")
 
           @default_request_headers = params[:default_request_headers] || {}
-          @default_request_headers['x-api-key'] = params[:api_key] || ''
+          @metrics_api_key = params[:metrics_api_key] || ''
+          @delivery_api_key = params[:delivery_api_key] || ''
 
           @default_only_log        = params[:default_only_log] || false
           @should_apply_treatment_func  = params[:should_apply_treatment_func]
@@ -66,22 +67,6 @@ module Promoted
           @pool.wait_for_termination
         end
 
-        def send_request payload, endpoint, timeout_millis, headers=[], send_async=false
-          use_headers = @default_request_headers.merge headers
-          
-          if send_async
-            @pool.post do
-              @http_client.send(endpoint, timeout_millis, payload, use_headers)
-            end
-          else
-            begin
-              @http_client.send(endpoint, timeout_millis, payload, use_headers)
-            rescue Faraday::Error => err
-              raise EndpointError.new(err)
-            end
-          end
-        end
-
         def deliver args, headers={}
           args = Promoted::Ruby::Client::Util.translate_args(args)
 
@@ -105,7 +90,7 @@ module Promoted
   
               # Call Delivery API
               begin
-                response = send_request(delivery_request_params, @delivery_endpoint, @delivery_timeout_millis, headers)
+                response = send_request(delivery_request_params, @delivery_endpoint, @delivery_timeout_millis, @delivery_api_key, headers)
               rescue  StandardError => err
                 # Currently we don't propagate errors to the SDK caller, but rather default to returning
                 # the request insertions.
@@ -191,7 +176,7 @@ module Promoted
         # Sends a log request (previously created by a call to prepare_for_logging) to the metrics endpoint.
         def send_log_request log_request_params, headers={}
           begin
-            send_request(log_request_params, @metrics_endpoint, @metrics_timeout_millis, headers)
+            send_request(log_request_params, @metrics_endpoint, @metrics_timeout_millis, @metrics_api_key, headers)
           rescue  StandardError => err
             # Currently we don't propagate errors to the SDK caller.
             @logger.error("Error from metrics: " + err.message) if @logger
@@ -199,6 +184,24 @@ module Promoted
         end
 
         private
+
+        def send_request payload, endpoint, timeout_millis, api_key, headers={}, send_async=false
+          headers["x-api-key"] = api_key
+          use_headers = @default_request_headers.merge headers
+          
+          if send_async
+            @pool.post do
+              @http_client.send(endpoint, timeout_millis, payload, use_headers)
+            end
+          else
+            begin
+              @http_client.send(endpoint, timeout_millis, payload, use_headers)
+            rescue Faraday::Error => err
+              raise EndpointError.new(err)
+            end
+          end
+        end
+
 
         def add_missing_ids_on_insertions! request, insertions
           insertions.each do |insertion|
@@ -223,7 +226,7 @@ module Promoted
           delivery_request_params[:client_info][:traffic_type] = Promoted::Ruby::Client::TRAFFIC_TYPE['SHADOW']
 
           # Call Delivery API async (fire and forget)
-          send_request(delivery_request_params, @delivery_endpoint, @delivery_timeout_millis, headers, true)
+          send_request(delivery_request_params, @delivery_endpoint, @delivery_timeout_millis, @delivery_api_key, headers, true)
         end
 
         def perform_common_checks!(req)

--- a/spec/promoted/ruby/client_spec.rb
+++ b/spec/promoted/ruby/client_spec.rb
@@ -197,7 +197,21 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       expect(delivery_req[:request].key?(:use_case)).to be true
       expect(delivery_req[:request].key?(:properties)).to be true
     end
-
+        
+    it "passes the endpoint and api key" do
+      client = described_class.new(ENDPOINTS.merge( { :shadow_traffic_delivery_percent => 1.0, :delivery_api_key => "my api key" } ))
+      recv_headers = nil
+      recv_endpoint = nil
+      allow(client.http_client).to receive(:send) { |endpoint, timeout, request, headers|
+        recv_endpoint = endpoint
+        recv_headers = headers
+      }
+      expect { client.prepare_for_logging(input_with_unpaged) }.not_to raise_error
+      expect(recv_endpoint).to eq(ENDPOINTS[:delivery_endpoint])
+      expect(recv_headers.key?("x-api-key")).to be true
+      expect(recv_headers["x-api-key"]).to eq("my api key")
+    end  
+    
     # Exists for trying out Async HTTP in debugging
     # it "will send a 'real' request" do
     #   client = described_class.new({:shadow_traffic_delivery_percent => 1.0, :delivery_endpoint => "https://httpbin.org/anything", :metrics_endpoint => "https://httpbin.org/anything" })
@@ -236,6 +250,21 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       logging_json = client.prepare_for_logging(input)
       expect { client.send_log_request(logging_json) }.not_to raise_error
     end  
+
+    it "passes the endpoint and api key" do
+      client = described_class.new(ENDPOINTS.merge( { :metrics_api_key => "my api key" } ))
+      recv_headers = nil
+      recv_endpoint = nil
+      allow(client.http_client).to receive(:send) { |endpoint, timeout, request, headers|
+        recv_endpoint = endpoint
+        recv_headers = headers
+      }
+      logging_json = client.prepare_for_logging(input)
+      expect { client.send_log_request(logging_json) }.not_to raise_error
+      expect(recv_endpoint).to eq(ENDPOINTS[:metrics_endpoint])
+      expect(recv_headers.key?("x-api-key")).to be true
+      expect(recv_headers["x-api-key"]).to eq("my api key")
+    end  
   end
 
   context "deliver" do
@@ -262,6 +291,20 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       end
     end
     
+    it "passes the endpoint and api key" do
+      client = described_class.new(ENDPOINTS.merge( { :delivery_api_key => "my api key" } ))
+      recv_headers = nil
+      recv_endpoint = nil
+      allow(client.http_client).to receive(:send) { |endpoint, timeout, request, headers|
+        recv_endpoint = endpoint
+        recv_headers = headers
+      }
+      expect { client.deliver(input) }.not_to raise_error
+      expect(recv_endpoint).to eq(ENDPOINTS[:delivery_endpoint])
+      expect(recv_headers.key?("x-api-key")).to be true
+      expect(recv_headers["x-api-key"]).to eq("my api key")
+    end  
+        
     it "delivers in a good case" do
       client = described_class.new
       full_insertion = @input[:fullInsertion]


### PR DESCRIPTION
I also fixed a bug in send_request with the headers parameter.