### PR TITLE
Empty insertions from deliver should be returned\rTESTING=unit

### DIFF
--- a/lib/promoted/ruby/client/request_builder.rb
+++ b/lib/promoted/ruby/client/request_builder.rb
@@ -61,6 +61,10 @@ module Promoted
         # Maps the response insertions to the full insertions and re-insert the properties bag
         # to the responses.
         def fill_details_from_response response_insertions
+          if !response_insertions then
+            response_insertions = full_insertion
+          end
+
           props = @full_insertion.each_with_object({}) do |insertion, hash|
             hash[insertion[:content_id]] = insertion[:properties]
           end

--- a/spec/promoted/ruby/client_spec.rb
+++ b/spec/promoted/ruby/client_spec.rb
@@ -319,6 +319,36 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       expect(deliver_resp[:log_request]).to be nil
     end
 
+    it "delivers with empty insertions, which is not an error" do
+      client = described_class.new
+      full_insertion = @input[:fullInsertion]
+      expect(client).to receive(:send_request).and_return({
+        :insertion => []
+      })
+      deliver_resp = client.deliver @input
+      expect(deliver_resp).not_to be nil
+      expect(deliver_resp.key?(:insertion)).to be true
+      expect(deliver_resp[:insertion].length()).to be 0
+
+      # No log request generated since there's no experiment and we delivered the request.
+      expect(deliver_resp[:log_request]).to be nil
+    end
+
+    it "delivers with nil insertions, which should default to request insertions" do
+      client = described_class.new
+      full_insertion = @input[:fullInsertion]
+      expect(client).to receive(:send_request).and_return({
+        :insertion => nil
+      })
+      deliver_resp = client.deliver @input
+      expect(deliver_resp).not_to be nil
+      expect(deliver_resp.key?(:insertion)).to be true
+      expect(deliver_resp[:insertion].length()).to be full_insertion.length()
+
+      # No log request generated since there's no experiment and we delivered the request.
+      expect(deliver_resp[:log_request]).to be nil
+    end
+
     it "does not delivery for request only_log" do
       client = described_class.new
       @input[:only_log] = true


### PR DESCRIPTION
Per discussion, when deliver returns empty insertions but non-error, we set them on the client response, consistent with the TypeScript client.