### PR TITLE
Reorder middlewares to avoid Faraday warning\rTESTING=unit,manual

### DIFF
--- a/lib/promoted/ruby/client/faraday_http_client.rb
+++ b/lib/promoted/ruby/client/faraday_http_client.rb
@@ -10,8 +10,8 @@ module Promoted
                 @conn = Faraday.new do |f|
                     f.request :json
                     f.request :retry, max: 3
-                    f.adapter :net_http
                     f.use Faraday::Response::RaiseError # raises on 4xx and 5xx responses
+                    f.adapter :net_http
                 end
             end
 


### PR DESCRIPTION
This warning doesn't show up when I do my integration testing locally for some reason, but a quick search shows it may technically matter one day, i.e. https://github.com/lostisland/faraday/issues/717