### PR TITLE
Fix shape of request that goes to delivery API\rTESTING=unit

### DIFF
--- a/lib/promoted/ruby/client/request_builder.rb
+++ b/lib/promoted/ruby/client/request_builder.rb
@@ -48,10 +48,16 @@ module Promoted
           params = {
             user_info: user_info,
             timing: timing,
-            cohort_membership: @experiment,
-            client_info: @client_info.merge({ :client_type => Promoted::Ruby::Client::CLIENT_TYPE['PLATFORM_SERVER'] })
+            client_info: @client_info.merge({ :client_type => Promoted::Ruby::Client::CLIENT_TYPE['PLATFORM_SERVER'] }),
+            platform_id: @platform_id,
+            request_id: @request_id,
+            view_id: @view_id,
+            session_id: @session_id,
+            use_case: @use_case,
+            search_query: request[:search_query],
+            properties: request[:properties],
+            paging: request[:paging]
           }
-          params[:request] = request
           params[:insertion] = should_compact ? compact_delivery_insertions : full_insertion
 
           params.clean!

--- a/spec/promoted/ruby/client_spec.rb
+++ b/spec/promoted/ruby/client_spec.rb
@@ -207,7 +207,6 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       expect(delivery_req.key?(:use_case)).to be true
       expect(delivery_req.key?(:properties)).to be true
       expect(delivery_req.key?(:request_id)).to be true
-      pp delivery_req.to_json
     end
         
     it "passes the endpoint, timeout, and api key" do

--- a/spec/promoted/ruby/client_spec.rb
+++ b/spec/promoted/ruby/client_spec.rb
@@ -203,10 +203,11 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       expect(delivery_req.key?(:client_info)).to be true
       expect(delivery_req[:client_info][:traffic_type]).to be Promoted::Ruby::Client::TRAFFIC_TYPE['SHADOW']
       expect(delivery_req[:client_info][:client_type]).to be Promoted::Ruby::Client::CLIENT_TYPE['PLATFORM_SERVER']
-      expect(delivery_req.key?(:request)).to be true
-      expect(delivery_req[:request].key?(:user_info)).to be true
-      expect(delivery_req[:request].key?(:use_case)).to be true
-      expect(delivery_req[:request].key?(:properties)).to be true
+      expect(delivery_req.key?(:user_info)).to be true
+      expect(delivery_req.key?(:use_case)).to be true
+      expect(delivery_req.key?(:properties)).to be true
+      expect(delivery_req.key?(:request_id)).to be true
+      pp delivery_req.to_json
     end
         
     it "passes the endpoint, timeout, and api key" do


### PR DESCRIPTION
Previously, the request was on a child object instead of pulling its properties to the top level of the message. Now, the JSON will look like this, please double-check that it makes sense:

```
{
  "user_info": {
    "user_id": "912",
    "log_user_id": "91232"
  },
  "timing": {
    "client_log_timestamp": 1625681762
  },
  "client_info": {
    "client_type": "PLATFORM_SERVER",
    "traffic_type": "SHADOW"
  },
  "request_id": "c9a33a1b-794f-469e-b27a-dc0d5b36888f",
  "use_case": "FEED",
  "properties": {
    "struct": {}
  },
  "insertion": [
    {
      "content_id": "5b4a6512326bd9777abfabc34",
      "properties": {
        "invites_required": 0,
        "total_uses": 738,
        "last_used_at": "2021-05-24T22:35:31.149Z",
        "last_purchase_at": "2021-05-24T22:35:31.214Z",
        "some_property_2": "some value..."
      },
      "session_id": "uuid0",
      "view_id": "uuid0"
    },
    {
      "content_id": "5b4a6512326bd9777abfabcf",
      "properties": {
        "invites_required": 0,
        "total_uses": 738,
        "last_used_at": "2021-05-24T22:35:31.149Z",
        "last_purchase_at": "2021-05-24T22:35:31.214Z",
        "some_property_2": "some value..."
      },
      "session_id": "uuid1",
      "view_id": "uuid1"
    },
    {
      "content_id": "5b4a6512326bd9777abfabcf",
      "properties": {
        "invites_required": 0,
        "total_uses": 738,
        "last_used_at": "2021-05-24T22:35:31.149Z",
        "last_purchase_at": "2021-05-24T22:35:31.214Z",
        "some_property_2": "some value..."
      },
      "session_id": "uuid2",
      "view_id": "uuid2"
    },
    {
      "content_id": "5b4a6512326bd9777abfabcf",
      "properties": {
        "invites_required": 0,
        "total_uses": 738,
        "last_used_at": "2021-05-24T22:35:31.149Z",
        "last_purchase_at": "2021-05-24T22:35:31.214Z",
        "some_property_2": "some value..."
      },
      "session_id": "uuid3",
      "view_id": "uuid3"
    },
    {
      "content_id": "5b4a6512326bd9777abfabcf",
      "properties": {
        "invites_required": 0,
        "total_uses": 738,
        "last_used_at": "2021-05-24T22:35:31.149Z",
        "last_purchase_at": "2021-05-24T22:35:31.214Z",
        "some_property_2": "some value..."
      },
      "session_id": "uuid4",
      "view_id": "uuid4"
    }
  ]
}
```