### PR TITLE
Hook up request logging via config\rTESTING=unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ This client will suffice for building log requests. To send actually send traffi
 
 ```rb
 client = Promoted::Ruby::Client::PromotedClient.new({
-  :metrics_endpoint = "https://<get this from Promoted>",
-  :delivery_endpoint = "https://<get this from Promoted>",
-  :metrics_api_key = "<get this from Promoted>",
-  :delivery_api_key = "<get this from Promoted>"
+  :metrics_endpoint => "https://<get this from Promoted>",
+  :delivery_endpoint => "https://<get this from Promoted>",
+  :metrics_api_key => "<get this from Promoted>",
+  :delivery_api_key => "<get this from Promoted>"
 })
 ```
 

--- a/spec/promoted/ruby/client_spec.rb
+++ b/spec/promoted/ruby/client_spec.rb
@@ -171,6 +171,7 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       client = described_class.new(ENDPOINTS.merge({ :shadow_traffic_delivery_percent => 1.0, :perform_checks => false }))
       expect(client).to receive(:send_request)
       expect { client.prepare_for_logging(input) }.not_to raise_error
+      client.close
     end
 
     it "samples in" do
@@ -178,6 +179,7 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       client = described_class.new(ENDPOINTS.merge({ :shadow_traffic_delivery_percent => 0.6 }))
       expect(client).to receive(:send_request)
       expect { client.prepare_for_logging(input_with_unpaged) }.not_to raise_error
+      client.close
     end
 
     it "samples out" do
@@ -188,7 +190,7 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
     end
 
     it "works in a normal case" do
-      client = described_class.new(ENDPOINTS.merge({:shadow_traffic_delivery_percent => 1.0 }))
+      client = described_class.new(ENDPOINTS.merge({ :shadow_traffic_delivery_percent => 1.0 }))
 
       delivery_req = nil
       expect(client).to receive(:send_request) {|value|
@@ -196,6 +198,7 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       }
 
       expect { client.prepare_for_logging(input_with_unpaged) }.not_to raise_error
+      client.close
 
       expect(delivery_req.key?(:insertion)).to be true
       expect(delivery_req[:insertion].length()).to be 5
@@ -220,6 +223,8 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
         recv_timeout = timeout
       }
       expect { client.prepare_for_logging(input_with_unpaged) }.not_to raise_error
+      client.close
+
       expect(recv_endpoint).to eq(ENDPOINTS[:delivery_endpoint])
       expect(recv_headers.key?("x-api-key")).to be true
       expect(recv_headers["x-api-key"]).to eq("my api key")

--- a/spec/promoted/ruby/client_spec.rb
+++ b/spec/promoted/ruby/client_spec.rb
@@ -171,7 +171,6 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       client = described_class.new(ENDPOINTS.merge({ :shadow_traffic_delivery_percent => 1.0, :perform_checks => false }))
       expect(client).to receive(:send_request)
       expect { client.prepare_for_logging(input) }.not_to raise_error
-      client.close
     end
 
     it "samples in" do
@@ -179,7 +178,6 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       client = described_class.new(ENDPOINTS.merge({ :shadow_traffic_delivery_percent => 0.6 }))
       expect(client).to receive(:send_request)
       expect { client.prepare_for_logging(input_with_unpaged) }.not_to raise_error
-      client.close
     end
 
     it "samples out" do
@@ -190,7 +188,7 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
     end
 
     it "works in a normal case" do
-      client = described_class.new(ENDPOINTS.merge({ :shadow_traffic_delivery_percent => 1.0 }))
+      client = described_class.new(ENDPOINTS.merge({:shadow_traffic_delivery_percent => 1.0 }))
 
       delivery_req = nil
       expect(client).to receive(:send_request) {|value|
@@ -198,7 +196,6 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       }
 
       expect { client.prepare_for_logging(input_with_unpaged) }.not_to raise_error
-      client.close
 
       expect(delivery_req.key?(:insertion)).to be true
       expect(delivery_req[:insertion].length()).to be 5
@@ -223,8 +220,6 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
         recv_timeout = timeout
       }
       expect { client.prepare_for_logging(input_with_unpaged) }.not_to raise_error
-      client.close
-
       expect(recv_endpoint).to eq(ENDPOINTS[:delivery_endpoint])
       expect(recv_headers.key?("x-api-key")).to be true
       expect(recv_headers["x-api-key"]).to eq("my api key")


### PR DESCRIPTION
Tested this manually with irb. Configure the client like:

logger = Logger.new(STDERR)
logger.level = Logger::INFO
client = Promoted::Ruby::Client::PromotedClient.new({
  :metrics_endpoint => "https://<get this from Promoted>",
  :delivery_endpoint => "https://<get this from Promoted>",
  :metrics_api_key => "<get this from Promoted>",
  :delivery_api_key => "<get this from Promoted>",
  :request_logging_on => true,
  :logger => logger 
})

Then requests will get logged something like:

INFO -- promotedai: Sending {"user_info":{"user_id":"912","log_user_id":"912191"},"timing":{"client_log_timestamp":1625702042},"client_info":{"client_type":"PLATFORM_SERVER"},"request_id":"2f7c234f-9373-45f3-bdac-1f11a5d99b3f","use_case":"FEED","properties":{"struct":{"active":true}},"paging":{"offset":0,"size":5},"insertion":[{"content_id":"123","properties":{"struct":{"type":"SHOE","name":"Blue shoe"}}},{"content_id":"124","properties":{"struct":{"type":"SHIRT","name":"Green shirt"}}},{"content_id":"125","properties":{"struct":{"type":"DRESS","name":"Red dress"}}}]} to https://<get this from Promoted>
