### PR TITLE
More complete paging impl and only_log when offset is out of range\rTESTING=unit

### DIFF
--- a/lib/promoted/ruby/client.rb
+++ b/lib/promoted/ruby/client.rb
@@ -61,6 +61,7 @@ module Promoted
           raise ArgumentError.new("Invalid shadow_traffic_delivery_percent, must be between 0 and 1") if @shadow_traffic_delivery_percent < 0 || @shadow_traffic_delivery_percent > 1.0
 
           @sampler = Sampler.new
+          @pager   = Pager.new
 
           # HTTP Client creation
           @delivery_endpoint = params[:delivery_endpoint] || DEFAULT_DELIVERY_ENDPOINT
@@ -115,7 +116,7 @@ module Promoted
           # Respect the enabled state
           if !@enabled
             return {
-              insertion: apply_paging(args[:full_insertion], args[:request][:paging])
+              insertion: @pager.apply_paging(args[:full_insertion], Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'], args[:request][:paging])
               # No log request returned when disabled
             }
           end
@@ -133,6 +134,13 @@ module Promoted
 
           only_log = delivery_request_builder.only_log != nil ? delivery_request_builder.only_log : @default_only_log
           deliver_err = false
+
+          if !@pager.validate_paging(delivery_request_builder.full_insertion, delivery_request_builder.request[:paging])
+            # Invalid input, log and do SDK-side delivery.
+            @logger.warn("Invalid paging parameters") if @logger
+            only_log = true
+          end
+
           if !only_log
             cohort_membership_to_log = delivery_request_builder.new_cohort_membership_to_log
 
@@ -158,7 +166,7 @@ module Promoted
           request_to_log = nil
           if !insertions_from_delivery then
             request_to_log = delivery_request_builder.request
-            response_insertions = apply_paging(delivery_request_builder.full_insertion, delivery_request_builder.request[:paging])
+            response_insertions = @pager.apply_paging(delivery_request_builder.full_insertion, Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'], delivery_request_builder.request[:paging])
           end
 
           log_req = nil
@@ -239,14 +247,6 @@ module Promoted
         end
 
         private
-
-        def apply_paging full_insertion, paging
-          size = nil
-          if paging
-            size = paging[:size]
-          end
-          return size != nil ? full_insertion[0..size - 1] : full_insertion
-        end
 
         def send_request payload, endpoint, timeout_millis, api_key, headers={}, send_async=false
           resp = nil
@@ -331,6 +331,7 @@ end
 
 # dependent /libs
 require "promoted/ruby/client/request_builder"
+require "promoted/ruby/client/pager"
 require "promoted/ruby/client/sampler"
 require "promoted/ruby/client/util"
 require "promoted/ruby/client/validator"

--- a/lib/promoted/ruby/client/pager.rb
+++ b/lib/promoted/ruby/client/pager.rb
@@ -1,0 +1,57 @@
+module Promoted
+    module Ruby
+      module Client
+        class Pager
+            def validate_paging (insertions, paging)
+              if paging && paging[:offset]
+                return paging[:offset] < insertions.length
+              end
+              return true          
+            end
+
+            def apply_paging (insertions, insertion_page_type, paging = nil)
+              # This is invalid input, stop it before it goes to the server.
+              if !validate_paging(insertions, paging)
+                return []
+              end
+
+              if !paging
+                paging = {
+                  :offset => 0,
+                  :size => insertions.length
+                }
+              end
+
+              offset = [0, paging[:offset]].max
+
+              index = offset
+              if insertion_page_type == Promoted::Ruby::Client::INSERTION_PAGING_TYPE['PRE_PAGED']
+                # When insertions are pre-paged, we don't use offset to
+                # window into the provided insertions, although we do use it when
+                # assigning positions.
+                index = 0
+              end
+
+              size = paging[:size]
+              if size <= 0
+                size = insertions.length
+              end
+
+              final_insertion_size = [size, insertions.length].min
+              insertion_page = Array.new(final_insertion_size)
+              0.upto(final_insertion_size - 1) {|i|
+                insertion = insertions[index]
+                if insertion[:position] == nil
+                  insertion[:position] = offset
+                end
+                insertion_page[i] = insertion
+                index = index + 1
+                offset = offset + 1
+              }
+
+              return insertion_page
+            end
+        end
+      end
+   end
+end

--- a/spec/promoted/ruby/client/pager_spec.rb
+++ b/spec/promoted/ruby/client/pager_spec.rb
@@ -1,0 +1,175 @@
+require 'spec_helper'
+
+RSpec.describe Promoted::Ruby::Client::Pager do
+  before(:each) do
+    @insertions = [
+      {
+        :insertion_id => "uuid0-0",
+        :request_id => "uuid0-1",
+        :view_id => "uuid0-2"
+      },
+      {
+        :insertion_id => "uuid1-0",
+        :request_id => "uuid1-1",
+        :view_id => "uuid1-2"
+      },
+      {
+        :insertion_id => "uuid2-0",
+        :request_id => "uuid2-1",
+        :view_id => "uuid2-2"
+      }
+    ]
+  end
+
+  context "apply paging" do
+    it "pages a window when unpaged" do
+        paging = {
+          :size => 2,
+          :offset => 1
+        }
+
+        pager = subject.class.new
+        res = pager.apply_paging(@insertions, Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'], paging)
+        expect(res.length).to eq @insertions.length - 1
+
+        # We take a page size of 2 starting at offset 1
+        expect(res[0][:insertion_id]).to eq @insertions[1][:insertion_id]
+        expect(res[1][:insertion_id]).to eq @insertions[2][:insertion_id]
+
+        # Positions start at offset when unpaged.
+        expect(res[0][:position]).to eq 1
+        expect(res[1][:position]).to eq 2
+    end
+
+    it "pages a window when prepaged" do
+      paging = {
+        :size => 2,
+        :offset => 1
+      }
+
+      pager = subject.class.new
+      res = pager.apply_paging(@insertions, Promoted::Ruby::Client::INSERTION_PAGING_TYPE['PRE_PAGED'], paging)
+      expect(res.length).to eq @insertions.length - 1
+
+      # We take a page size of 2 starting at the beginning since prepaged.
+      expect(res[0][:insertion_id]).to eq @insertions[0][:insertion_id]
+      expect(res[1][:insertion_id]).to eq @insertions[1][:insertion_id]
+
+      # Positions start at offset.
+      expect(res[0][:position]).to eq 1
+      expect(res[1][:position]).to eq 2
+    end
+
+    it "returns everything when no paging provided" do
+      paging = {
+        :size => 2,
+        :offset => 1
+      }
+
+      pager = subject.class.new
+      res = pager.apply_paging(@insertions, Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'])
+      expect(res.length).to eq @insertions.length
+
+      # Should assign positions since they weren't already set.
+      expect(res[0][:position]).to eq 0
+      expect(res[1][:position]).to eq 1
+      expect(res[2][:position]).to eq 2
+    end
+
+    it "does not touch positions that are already set" do
+      @insertions[0][:position] = 100
+      @insertions[1][:position] = 101
+      @insertions[2][:position] = 102
+
+      pager = subject.class.new
+      res = pager.apply_paging(@insertions, Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'])
+      expect(res.length).to eq @insertions.length
+
+      # Should leave positions alone that were already set, presumably these came from Delivery API.
+      expect(res[0][:position]).to eq 100
+      expect(res[1][:position]).to eq 101
+      expect(res[2][:position]).to eq 102
+    end
+
+    it "handles empty input for unpaged" do
+      pager = subject.class.new
+      res = pager.apply_paging([], Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'])
+      expect(res.length).to eq 0
+    end
+
+    it "handles empty input for prepaged" do
+      pager = subject.class.new
+      res = pager.apply_paging([], Promoted::Ruby::Client::INSERTION_PAGING_TYPE['PRE_PAGED'])
+      expect(res.length).to eq 0
+    end
+
+    it "handles empty input when paging provided" do
+      paging = {
+        :size => 1,
+        :offset => 1
+      }
+
+      pager = subject.class.new
+      res = pager.apply_paging([], Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'], paging)
+      expect(res.length).to eq 0
+    end
+
+    it "returns everything with huge page size" do
+      paging = {
+        :size => 100,
+        :offset => 0
+      }
+
+      pager = subject.class.new
+      res = pager.apply_paging(@insertions, Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'], paging)
+      expect(res.length).to eq @insertions.length
+    end
+
+    it "returns everything with invalid page size" do
+      paging = {
+        :size => -1,
+        :offset => 0
+      }
+
+      pager = subject.class.new
+      res = pager.apply_paging(@insertions, Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'], paging)
+      expect(res.length).to eq @insertions.length
+    end
+
+    it "returns everything with invalid page size" do
+      paging = {
+        :size => -1,
+        :offset => 0
+      }
+
+      pager = subject.class.new
+      res = pager.apply_paging(@insertions, Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'], paging)
+      expect(res.length).to eq @insertions.length
+    end
+
+    it "handles invalid offset by starting at 0" do
+      paging = {
+        :size => 100,
+        :offset => -1
+      }
+
+      pager = subject.class.new
+      res = pager.apply_paging(@insertions, Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'], paging)
+      expect(res.length).to eq @insertions.length
+      expect(res[0][:position]).to eq 0
+      expect(res[1][:position]).to eq 1
+      expect(res[2][:position]).to eq 2
+    end
+
+    it "handles out of range offset" do
+      paging = {
+        :size => 1,
+        :offset => 10
+      }
+
+      pager = subject.class.new
+      res = pager.apply_paging(@insertions, Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'], paging)
+      expect(res.length).to eq 0
+    end
+  end
+end

--- a/spec/promoted/ruby/client_spec.rb
+++ b/spec/promoted/ruby/client_spec.rb
@@ -518,6 +518,17 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       expect(resp[:log_request]).to be nil
     end
 
+    it "does not deliver but logs with invalid paging parameters" do
+      dup_input = Marshal.load(Marshal.dump(@input))
+      dup_input[:request][:paging] = { size: 1, offset: 100000 }
+
+      client = described_class.new
+      resp = client.deliver dup_input
+      expect(client).not_to receive(:send_request)
+      expect(resp[:insertion].length).to be 0
+      expect(resp[:log_request]).not_to be nil
+    end
+
     it "does not deliver when disabled, with paging" do
       dup_input = Marshal.load(Marshal.dump(@input))
       dup_input[:request][:paging] = { size: 1, offset: 0 }


### PR DESCRIPTION
This is a straight port of the latest TypeScript work (including the unit tests), with the caveat that the client currently doesn't take an insertion_paging_type but rather assumes everything is UNPAGED (so the behavior should be the same). The one addition is that out-of-range offsets will return [] via the only_log behavior in deliver.