### PR TITLE
fix: make faraday dependency flexible

### DIFF
--- a/promoted-ruby-client.gemspec
+++ b/promoted-ruby-client.gemspec
@@ -37,9 +37,9 @@ Gem::Specification.new do |spec|
   spec.executables      = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths    = ["lib"]
 
-  spec.add_runtime_dependency 'faraday', '~> 1.4', '>= 1.4.3'
-  spec.add_runtime_dependency 'faraday_middleware', '~> 1.0', '>= 1.0.0'
-  spec.add_runtime_dependency 'faraday-net_http', '~> 1.0'
+  spec.add_runtime_dependency 'faraday', '>= 0.9.0'
+  spec.add_runtime_dependency 'faraday_middleware', '>= 0.9.0'
+  spec.add_runtime_dependency 'faraday-net_http', '>= 0.9.0'
   spec.add_runtime_dependency 'net-http-persistent', '~> 4.0'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1'
 


### PR DESCRIPTION
This gives us a bunch of warning.

```
❯ gem build promoted-ruby-client.gemspec
WARNING:  open-ended dependency on faraday (>= 0.9.0) is not recommended
  if faraday is semantically versioned, use:
    add_runtime_dependency 'faraday', '~> 0.9', '>= 0.9.0'
WARNING:  open-ended dependency on faraday_middleware (>= 0.9.0) is not recommended
  if faraday_middleware is semantically versioned, use:
    add_runtime_dependency 'faraday_middleware', '~> 0.9', '>= 0.9.0'
WARNING:  open-ended dependency on faraday-net_http (>= 0.9.0) is not recommended
  if faraday-net_http is semantically versioned, use:
    add_runtime_dependency 'faraday-net_http', '~> 0.9', '>= 0.9.0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: promoted-ruby-client
  Version: 0.1.13
  File: promoted-ruby-client-0.1.13.gem
```