### PR TITLE
[WIP] fix: change Response.insertion == nil to act like []

### DIFF
--- a/lib/promoted/ruby/client.rb
+++ b/lib/promoted/ruby/client.rb
@@ -175,7 +175,7 @@ module Promoted
               
               insertions_from_delivery = (response != nil && !deliver_err);
               response_insertions = delivery_request_builder.fill_details_from_response(
-                response ? response[:insertion] : [])
+                response && response[:insertion] || [])
             end
           end
   
@@ -357,7 +357,7 @@ module Promoted
           
           if !@async_shadow_traffic
             ellapsed_time = Time.now - start_time
-            insertions = response ? response[:insertion] : []
+            insertions = response && response[:insertion] || []
             @logger.info("Shadow traffic call completed in #{ellapsed_time.to_f * 1000} ms with #{insertions.length} insertions") if @logger
           end
         end

--- a/lib/promoted/ruby/client/request_builder.rb
+++ b/lib/promoted/ruby/client/request_builder.rb
@@ -78,7 +78,7 @@ module Promoted
         # to the responses.
         def fill_details_from_response response_insertions
           if !response_insertions then
-            response_insertions = full_insertion
+            response_insertions = []
           end
 
           props = @full_insertion.each_with_object({}) do |insertion, hash|

--- a/spec/promoted/ruby/client_spec.rb
+++ b/spec/promoted/ruby/client_spec.rb
@@ -457,7 +457,7 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       expect(deliver_resp[:log_request]).to be nil
     end
 
-    it "delivers with nil insertions, which should default to request insertions" do
+    it "delivers with nil insertions, which is not an error" do
       client = described_class.new
       full_insertion = @input[:fullInsertion]
       expect(client).to receive(:send_request).and_return({
@@ -466,7 +466,7 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       deliver_resp = client.deliver @input
       expect(deliver_resp).not_to be nil
       expect(deliver_resp.key?(:insertion)).to be true
-      expect(deliver_resp[:insertion].length()).to be full_insertion.length()
+      expect(deliver_resp[:insertion].length()).to be 0
       expect(deliver_resp[:execution_server]).to eq(Promoted::Ruby::Client::EXECUTION_SERVER['API'])
       expect(deliver_resp[:client_request_id]).not_to be nil
 


### PR DESCRIPTION
I marked as WIP because I'm not in a rush to get this in and the direction might change after review.  I'm also not a ruby expert so I could be messing this up.  This is a partial rollback to the previous way but converts nil as [].

I don't remember the full context around the previous PR.  promoted-ts-client treats nil and [] as the same.  I didn't see any Delivery API logic for rendering out insertion == nil as an empty array.  Protos should default not set and empty array to the same value.  If Delivery API returns a successful deliver call and insertions is nil, I think that should be treated like an empty array.  Delivery API needs to make sure to send an error if it actually hit an error so SDKs can handle it.

It's okay for the offset>=len(items) case to exist with this because, if we assume it's valid input, it'd return an empty list of response insertions anyways.

The current behavior (if response.insertion==nil, then return fullInsertions) is not good and will likely break eventually.  For deliver, we want to return a paged list of items.

TESTING=rspec