### PR TITLE
Create insertion ids for sdk-side delivery, and do not overwrite inse…

### DIFF
--- a/lib/promoted/ruby/client.rb
+++ b/lib/promoted/ruby/client.rb
@@ -190,7 +190,7 @@ module Promoted
           request_to_log = nil
           if !insertions_from_delivery then
             request_to_log = delivery_request_builder.request
-            response_insertions = @pager.apply_paging(delivery_request_builder.full_insertion, Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'], delivery_request_builder.request[:paging])
+            response_insertions = build_sdk_response_insertions(delivery_request_builder)
           end
 
           log_req = nil
@@ -274,6 +274,14 @@ module Promoted
 
         private
 
+        ##
+        # Creates response insertions for SDK-side delivery, when we don't get response insertions from Delivery API.
+        def build_sdk_response_insertions delivery_request_builder
+          response_insertions = @pager.apply_paging(delivery_request_builder.full_insertion, Promoted::Ruby::Client::INSERTION_PAGING_TYPE['UNPAGED'], delivery_request_builder.request[:paging])
+          delivery_request_builder.add_missing_insertion_ids! response_insertions
+          return response_insertions
+        end
+        
         def do_warmup
           if !@delivery_endpoint
             # Warmup only supported when delivery is enabled.

--- a/lib/promoted/ruby/client/request_builder.rb
+++ b/lib/promoted/ruby/client/request_builder.rb
@@ -178,13 +178,18 @@ module Promoted
             insertion_obj                = Hash[insertion_obj]
             insertion_obj[:user_info]    = user_info
             insertion_obj[:timing]       = timing
-            insertion_obj[:insertion_id] = @id_generator.newID
             insertion_obj[:request_id]   = request_id
             insertion_obj[:position]     = offset + index
             insertion_obj                = compact_one_insertion(insertion_obj, @to_compact_metrics_properties_func)
             @insertion << insertion_obj.clean!
           end
           @insertion
+        end
+
+        def add_missing_insertion_ids! insertions
+          insertions.each do |insertion|
+            insertion[:insertion_id] = @id_generator.newID if not insertion[:insertion_id]
+          end
         end
 
         def client_request_id
@@ -202,10 +207,10 @@ module Promoted
         
         def add_missing_ids_on_insertions! request, insertions
           insertions.each do |insertion|
-            insertion[:insertion_id] = @id_generator.newID if not insertion[:insertion_id]
             insertion[:session_id] = request[:session_id] if request[:session_id]
             insertion[:request_id] = request[:request_id] if request[:request_id]
           end
+          add_missing_insertion_ids! insertions
         end
 
         # A list of the response Insertions.  This client expects lists to be truncated

--- a/spec/promoted/ruby/client/request_builder_spec.rb
+++ b/spec/promoted/ruby/client/request_builder_spec.rb
@@ -32,6 +32,30 @@ RSpec.describe Promoted::Ruby::Client::RequestBuilder do
     end
   end
 
+  context "add_missing_insertion_ids" do
+    it "adds missing insertion ids" do
+      insertions = [
+        { :content_id=>"5b4a6512326bd9777abfabc34" },
+        { :content_id=>"5b4a6512326bd9777abfabea" },
+      ]
+      request_builder = subject.class.new({:id_generator => FakeIdGenerator.new })
+      request_builder.add_missing_insertion_ids! insertions
+      expect(insertions[0][:insertion_id]).to eq "10"
+      expect(insertions[1][:insertion_id]).to eq "10"
+    end
+
+    it "respects existing insertion ids" do
+      insertions = [
+        { :content_id=>"5b4a6512326bd9777abfabc34", :insertion_id => "1" },
+        { :content_id=>"5b4a6512326bd9777abfabea", :insertion_id => "2" },
+      ]
+      request_builder = subject.class.new({:id_generator => FakeIdGenerator.new })
+      request_builder.add_missing_insertion_ids! insertions
+      expect(insertions[0][:insertion_id]).to eq "1"
+      expect(insertions[1][:insertion_id]).to eq "2"
+    end
+  end
+
   context "delivery_request_params" do
     it "should return expected delivery request" do
       request_builder = subject.class.new({:id_generator => FakeIdGenerator.new })

--- a/spec/promoted/ruby/client_spec.rb
+++ b/spec/promoted/ruby/client_spec.rb
@@ -523,6 +523,9 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       # Log request that follows up an unsent delivery request should have the same client request id.
       expect(log_request[:request][0][:client_request_id]).to eq(delivery_req[:client_request_id])
       expect(deliver_resp[:client_request_id]).to eq(delivery_req[:client_request_id])
+
+      # Should fill in insertion id
+      expect(deliver_resp[:insertion][0][:insertion_id]).not_to be nil
     end
     
     it "can compact insertions with all properties" do
@@ -705,7 +708,7 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       expect(delivery_req[:client_info][:traffic_type]).to eq Promoted::Ruby::Client::TRAFFIC_TYPE['SHADOW']
     end
 
-    it "does not delivers shadow traffic for control arm when the option is off" do
+    it "does not deliver shadow traffic for control arm when the option is off" do
       client = described_class.new({ :send_shadow_traffic_for_control => false })
       @input["experiment"]["arm"] = Promoted::Ruby::Client::COHORT_ARM['CONTROL']
       expect(client).not_to receive(:send_request)


### PR DESCRIPTION
…rtion id during compact\rTESTING=unit