### PR TITLE
Add retrieval rank and score to validator\rTESTING=unit

### DIFF
--- a/lib/promoted/ruby/client/validator.rb
+++ b/lib/promoted/ruby/client/validator.rb
@@ -59,6 +59,14 @@ module Promoted
                         {
                             :name => :delivery_score,
                             :type => Integer
+                        },
+                        {
+                            :name => :retrieval_rank,
+                            :type => Integer
+                        },
+                        {
+                            :name => :retrieval_score,
+                            :type => Float
                         }
                     ]
                 )

--- a/spec/promoted/ruby/client/validator_spec.rb
+++ b/spec/promoted/ruby/client/validator_spec.rb
@@ -221,6 +221,30 @@ RSpec.describe Promoted::Ruby::Client::Validator do
             dup_input[:full_insertion][0][:delivery_score] = "5"
             expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /delivery_score/)
         end       
+       
+        it "validates correct retrieval_rank type" do
+            dup_input = Marshal.load(Marshal.dump(input))
+            dup_input[:full_insertion][0][:retrieval_rank] = 5
+            expect { @v.validate_metrics_request!(dup_input) }.not_to raise_error
+        end
+
+        it "validates incorrect retrieval_rank type" do
+            dup_input = Marshal.load(Marshal.dump(input))
+            dup_input[:full_insertion][0][:retrieval_rank] = "5"
+            expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /retrieval_rank/)
+        end       
+       
+        it "validates correct retrieval_score type" do
+            dup_input = Marshal.load(Marshal.dump(input))
+            dup_input[:full_insertion][0][:retrieval_score] = 5.2
+            expect { @v.validate_metrics_request!(dup_input) }.not_to raise_error
+        end
+
+        it "validates incorrect retrieval_score type" do
+            dup_input = Marshal.load(Marshal.dump(input))
+            dup_input[:full_insertion][0][:retrieval_score] = "5.2"
+            expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /retrieval_score/)
+        end       
     end
 
     context "check log ids not set" do


### PR DESCRIPTION
Note that this is potentially a breaking change for current users of the SDK if they are currently passing strings instead of numbers in either of these fields.