### PR TITLE
fix: `deliver` shadow for `only_log=true`.  includes other refactorings.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    promoted-ruby-client (0.1.24)
+    promoted-ruby-client (1.0.0)
       concurrent-ruby (~> 1)
       faraday (>= 0.9.0)
       faraday_middleware (>= 0.9.0)

--- a/dev.md
+++ b/dev.md
@@ -4,5 +4,5 @@
 2. Get credentials for deployment from 1password.
 3. Modify `promoted-ruby-client.gemspec`'s push block.
 4. Run `gem build promoted-ruby-client.gemspec` to generate `gem`.
-5. Run (using new output) `gem push promoted-ruby-client-0.1.24.gem`
+5. Run (using new output) `gem push promoted-ruby-client-1.0.0.gem`
 6. Update README with new version.

--- a/lib/promoted/ruby/client/request_builder.rb
+++ b/lib/promoted/ruby/client/request_builder.rb
@@ -124,7 +124,7 @@ module Promoted
               }
             }]
 
-            add_missing_ids_on_insertions! request, params[:delivery_log][0][:response][:insertion]
+            add_missing_insertion_ids! params[:delivery_log][0][:response][:insertion]            
           end
           
           params.clean!
@@ -174,10 +174,6 @@ module Promoted
             :client_type => Promoted::Ruby::Client::CLIENT_TYPE['PLATFORM_SERVER'],
             :traffic_type => Promoted::Ruby::Client::TRAFFIC_TYPE['PRODUCTION']
           })
-        end
-        
-        def add_missing_ids_on_insertions! request, insertions
-          add_missing_insertion_ids! insertions
         end
       end
     end

--- a/lib/promoted/ruby/client/request_builder.rb
+++ b/lib/promoted/ruby/client/request_builder.rb
@@ -179,10 +179,6 @@ module Promoted
         def add_missing_ids_on_insertions! request, insertions
           add_missing_insertion_ids! insertions
         end
-
-        #def insertion
-        #  @insertion
-        #end
       end
     end
   end

--- a/lib/promoted/ruby/client/request_builder.rb
+++ b/lib/promoted/ruby/client/request_builder.rb
@@ -3,10 +3,9 @@ module Promoted
     module Client
       class RequestBuilder
         attr_reader   :session_id, :only_log, :experiment, :client_info, :device,
-                      :view_id, :insertion, :to_compact_delivery_properties_func,
-                      :request_id, :use_case, :request, :to_compact_metrics_properties_func
+                      :view_id, :insertion, :request_id, :use_case, :request
 
-        attr_accessor :timing, :user_info, :platform_id, :full_insertion
+        attr_accessor :timing, :user_info, :platform_id, :insertion
 
         def initialize args = {}
           if args[:id_generator]
@@ -27,11 +26,9 @@ module Promoted
           @device                  = request[:device] || {}
           @view_id                 = request[:view_id]
           @use_case                = Promoted::Ruby::Client::USE_CASES[request[:use_case]] || Promoted::Ruby::Client::USE_CASES['UNKNOWN_USE_CASE']
-          @full_insertion          = args[:full_insertion]
+          @insertion               = request[:insertion] || []
           @user_info               = request[:user_info] || { :user_id => nil, :log_user_id => nil}
           @timing                  = request[:timing] || { :client_log_timestamp => (Time.now.to_f * 1000).to_i }
-          @to_compact_metrics_properties_func       = args[:to_compact_metrics_properties_func]
-          @to_compact_delivery_properties_func      = args[:to_compact_delivery_properties_func]
 
           # If the user didn't create a client request id, we do it for them.
           request[:client_request_id] = request[:client_request_id] || @id_generator.newID
@@ -68,7 +65,7 @@ module Promoted
             paging: request[:paging],
             client_request_id: client_request_id
           }
-          params[:insertion] = insertions_with_compact_props(@to_compact_delivery_properties_func)
+          params[:insertion] = insertion
 
           params.clean!
         end
@@ -81,7 +78,7 @@ module Promoted
             response_insertions = []
           end
 
-          props = @full_insertion.each_with_object({}) do |insertion, hash|
+          props = @insertion.each_with_object({}) do |insertion, hash|
             if insertion.has_key?(:properties)
               # Don't add nil properties to response insertions.
               hash[insertion[:content_id]] = insertion[:properties]
@@ -123,7 +120,7 @@ module Promoted
               },
               request: request,
               response: {
-                insertion: insertions_with_compact_metrics_properties
+                insertion: response_insertion
               }
             }]
 
@@ -133,64 +130,31 @@ module Promoted
           params.clean!
         end
 
-        def compact_one_insertion(insertion, compact_func)
-          return insertion if (!compact_func || !insertion[:properties])
-
-          # Only need a copy if there are properties to compact.
-          compact_insertion = insertion.dup
-
-          # Let the custom function work with a deep copy of the properties.
-          # There's really no way to work with a shallow copy and still be able
-          # to restore the correct insertion properties after a call to delivery.
-          new_props =  Marshal.load(Marshal.dump(insertion[:properties]))
-          compact_insertion[:properties] = compact_func.call(new_props)
-          compact_insertion.clean!
-          return compact_insertion
-        end
-
-        def insertions_with_compact_props(compact_func)
-          if !compact_func
-            # Nothing to do, avoid copying the whole array.
-            full_insertion
-          else
-            compact_insertions = Array.new(full_insertion.length)
-            full_insertion.each_with_index {|insertion, index|
-              compact_insertions[index] = compact_one_insertion(insertion, compact_func)
-            }
-            compact_insertions
-          end
-        end
-
         def ensure_client_timestamp
           if timing[:client_log_timestamp].nil?
             timing[:client_log_timestamp] = (Time.now.to_f * 1000).to_i
           end
         end
 
-        # TODO: This looks overly complicated.
-        def insertions_with_compact_metrics_properties
-          @insertion            = [] # insertion should be set according to the compact insertion
+        def response_insertion
+          @response_insertions  = []
           paging                = request[:paging] || {}
           size                  = paging[:size] ? paging[:size].to_i : 0
           if size <= 0
-            size = full_insertion.length()
+            size = insertion.length()
           end
           offset                = paging[:offset] ? paging[:offset].to_i : 0
 
-          full_insertion.each_with_index do |insertion_obj, index|
+          insertion.each_with_index do |insertion_obj, index|
             # TODO - this does not look performant.
-            break if @insertion.length() >= size
-
-            insertion_obj                = insertion_obj.transform_keys{ |key| key.to_s.to_underscore.to_sym }
-            insertion_obj                = Hash[insertion_obj]
-            insertion_obj[:user_info]    = user_info
-            insertion_obj[:timing]       = timing
-            insertion_obj[:request_id]   = request_id
-            insertion_obj[:position]     = offset + index
-            insertion_obj                = compact_one_insertion(insertion_obj, @to_compact_metrics_properties_func)
-            @insertion << insertion_obj.clean!
+            break if @response_insertions.length() >= size
+            response_insertion = Hash[]
+            response_insertion[:content_id]   = insertion_obj[:content_id]
+            response_insertion[:position]     = offset + index
+            response_insertion[:insertion_id] = insertion_obj[:insertion_id]
+            @response_insertions << response_insertion.clean!
           end
-          @insertion
+          @response_insertions
         end
 
         def add_missing_insertion_ids! insertions
@@ -213,19 +177,12 @@ module Promoted
         end
         
         def add_missing_ids_on_insertions! request, insertions
-          insertions.each do |insertion|
-            insertion[:session_id] = request[:session_id] if request[:session_id]
-            insertion[:request_id] = request[:request_id] if request[:request_id]
-          end
           add_missing_insertion_ids! insertions
         end
 
-        # A list of the response Insertions.  This client expects lists to be truncated
-        # already to request.paging.size.  If not truncated, this client will truncate
-        # the list.
-        def insertion
-          @insertion
-        end
+        #def insertion
+        #  @insertion
+        #end
       end
     end
   end

--- a/lib/promoted/ruby/client/validator.rb
+++ b/lib/promoted/ruby/client/validator.rb
@@ -99,6 +99,7 @@ module Promoted
                         },
                         {
                             :name => :insertion,
+                            :required => true,
                             :type => Array
                         }
                     ]
@@ -115,6 +116,7 @@ module Promoted
                 end
             end
 
+            # TODO - delete?
             def validate_metrics_request!(metrics_req)
                 validate_fields!(
                     metrics_req,
@@ -123,33 +125,25 @@ module Promoted
                         {
                             :name => :request,
                             :required => true
-                        },
-                        {
-                            :name => :full_insertion,
-                            :required => true,
-                            :type => Array
                         }
                     ]
                 )
 
                 validate_request!(metrics_req[:request])
-                metrics_req[:full_insertion].each {|ins|
-                    validate_insertion! ins
-                }
             end
 
             def check_that_log_ids_not_set! req
+                raise ValidationError.new("Request should be set") if !req[:request]
                 raise ValidationError.new("Request.requestId should not be set") if req.dig(:request, :request_id)
-                raise ValidationError.new("Do not set Request.insertion.  Set full_insertion.") if req[:insertion]
       
-                req[:full_insertion].each do |insertion_hash|
+                req[:request][:insertion].each do |insertion_hash|
                   raise ValidationError.new("Insertion.requestId should not be set") if insertion_hash[:request_id]
                   raise ValidationError.new("'Insertion.insertionId should not be set") if insertion_hash[:insertion_id]
                 end
             end
             
             def check_that_content_ids_are_set! req
-              req[:full_insertion].each do |insertion_hash|
+              req[:request][:insertion].each do |insertion_hash|
                 raise ValidationError.new("Insertion.contentId should be set") if !insertion_hash[:content_id] || insertion_hash[:content_id].empty?
               end
             end

--- a/lib/promoted/ruby/client/version.rb
+++ b/lib/promoted/ruby/client/version.rb
@@ -1,7 +1,7 @@
 module Promoted
   module Ruby
     module Client
-      VERSION = "0.1.24"
+      VERSION = "1.0.0"
       SERVER_VERSION = "rb." + VERSION
     end
   end

--- a/promoted-ruby-client.gemspec
+++ b/promoted-ruby-client.gemspec
@@ -14,10 +14,18 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/promotedai/promoted-ruby-client'
   spec.license       = 'MIT'
 
-  spec.metadata["allowed_push_host"] = "https://rubygems.org/"
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/promotedai/promoted-ruby-client"
-  spec.metadata["changelog_uri"] = "https://github.com/promotedai/promoted-ruby-client/blob/master/CHANGELOG.md"
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
+  # to allow pushing to a single host or delete this section to allow pushing to any host.
+  if spec.respond_to?(:metadata)
+    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+
+    spec.metadata["homepage_uri"] = spec.homepage
+    spec.metadata["source_code_uri"] = "https://github.com/promotedai/promoted-ruby-client"
+    spec.metadata["changelog_uri"] = "https://github.com/promotedai/promoted-ruby-client/blob/master/CHANGELOG.md"
+  else
+    raise "RubyGems 2.0 or newer is required to protect against " \
+      "public gem pushes."
+  end
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/promoted-ruby-client.gemspec
+++ b/promoted-ruby-client.gemspec
@@ -14,18 +14,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/promotedai/promoted-ruby-client'
   spec.license       = 'MIT'
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
-
-    spec.metadata["homepage_uri"] = spec.homepage
-    spec.metadata["source_code_uri"] = "https://github.com/promotedai/promoted-ruby-client"
-    spec.metadata["changelog_uri"] = "https://github.com/promotedai/promoted-ruby-client/blob/master/CHANGELOG.md"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
+  spec.metadata["allowed_push_host"] = "https://rubygems.org/"
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/promotedai/promoted-ruby-client"
+  spec.metadata["changelog_uri"] = "https://github.com/promotedai/promoted-ruby-client/blob/master/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/promoted-ruby-client.gemspec
+++ b/promoted-ruby-client.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+    # Uncomment if you want to push to a custom host
+    # spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 
     spec.metadata["homepage_uri"] = spec.homepage
     spec.metadata["source_code_uri"] = "https://github.com/promotedai/promoted-ruby-client"

--- a/spec/promoted/ruby/client/request_builder_spec.rb
+++ b/spec/promoted/ruby/client/request_builder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Promoted::Ruby::Client::RequestBuilder do
       request_builder = subject.class.new
       request_builder.set_request_params(input)
       expect(request_builder.request).to eq(input[:request])
-      expect(request_builder.full_insertion).to eq(input[:full_insertion])
+      expect(request_builder.insertion).to eq(input[:request][:insertion])
     end
   end
 
@@ -64,7 +64,7 @@ RSpec.describe Promoted::Ruby::Client::RequestBuilder do
 
       expect(output.key?(:user_info)).to be true
       expect(output[:insertion].length).to be > 0
-      expect(output[:insertion].length).to eq input[:full_insertion].length
+      expect(output[:insertion].length).to eq input[:request][:insertion].length
       expect(output[:client_request_id]).to eq "10"
 
       # Delivery request should not fill in insertion ids.
@@ -95,14 +95,14 @@ RSpec.describe Promoted::Ruby::Client::RequestBuilder do
                   {
                     user_id: "912", log_user_id: "91232"
                   },
-                  client_info:
-                  {
-                    traffic_type: "PRODUCTION",
-                    client_type: "PLATFORM_SERVER"
-                  },
                   timing:
                   {
                     client_log_timestamp: request_builder.timing[:client_log_timestamp]
+                  },
+                  client_info:
+                  {
+                    client_type: "PLATFORM_SERVER",
+                    traffic_type: "PRODUCTION"
                   },
                   device: {
                     device_type: "DESKTOP",
@@ -112,9 +112,12 @@ RSpec.describe Promoted::Ruby::Client::RequestBuilder do
                     }
                   },
                   delivery_log: [{
+                    execution: {
+                      execution_server: "SDK",
+                      server_version: "rb." + Promoted::Ruby::Client::VERSION
+                    },
                     request: {
                       :user_info=> {:user_id=>"912", :log_user_id=>"91232"},
-                      :use_case=>"FEED",
                       device: {
                         device_type: "DESKTOP",
                         ip_address: "127.0.0.1",
@@ -122,6 +125,7 @@ RSpec.describe Promoted::Ruby::Client::RequestBuilder do
                             user_agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
                         }
                       },  
+                      :use_case=>"FEED",
                       :properties=>
                       {
                         :struct=>
@@ -129,54 +133,61 @@ RSpec.describe Promoted::Ruby::Client::RequestBuilder do
                           :query => {}
                         }
                       },
+                      client_request_id: "10",
                       request_id: "10",
-                      client_request_id: "10"
-                    },
-                    execution: {
-                      execution_server: "SDK",
-                      server_version: "rb." + Promoted::Ruby::Client::VERSION
+                      insertion:
+                      [{
+                        content_id: "5b4a6512326bd9777abfabc34",
+                        # TODO - this looks broken.
+                        properties: []
+                      },
+                      {
+                        content_id: "5b4a6512326bd9777abfabea",
+                        # TODO - this looks broken.
+                        properties: []
+                      },
+                      {
+                        content_id: "5b4a6512326bd9777abfabcf",
+                        # TODO - this looks broken.
+                        properties: []
+                      },
+                      {
+                        content_id: "5b4a6512326bd9777abfabcf",
+                        # TODO - this looks broken.
+                        properties: []
+                      },
+                      {
+                        content_id: "5b4a6512326bd9777abfabcf",
+                        # TODO - this looks broken.
+                        properties: []
+                      }]
                     },
                     response: {
                       insertion:
                       [{
                         content_id: "5b4a6512326bd9777abfabc34",
-                        user_info: {user_id: "912", log_user_id: "91232"},
-                        timing: {client_log_timestamp: request_builder.timing[:client_log_timestamp]},
-                        insertion_id: "10",
                         position: 0,
-                        request_id: "10"
+                        insertion_id: "10"
                       },
                       {
                         content_id: "5b4a6512326bd9777abfabea",
-                        user_info: {user_id: "912", log_user_id: "91232"},
-                        timing: {client_log_timestamp: request_builder.timing[:client_log_timestamp]},
-                        insertion_id: "10",
                         position: 1,
-                        request_id: "10"
+                        insertion_id: "10"
                       },
                       {
                         content_id: "5b4a6512326bd9777abfabcf",
-                        user_info: {user_id: "912", log_user_id: "91232"},
-                        timing: {client_log_timestamp: request_builder.timing[:client_log_timestamp]},
-                        insertion_id: "10",
                         position: 2,
-                        request_id: "10"
+                        insertion_id: "10",
                       },
                       {
                         content_id: "5b4a6512326bd9777abfabcf",
-                        user_info: {user_id: "912", log_user_id: "91232"},
-                        timing: {client_log_timestamp: request_builder.timing[:client_log_timestamp]},
-                        insertion_id: "10",
                         position: 3,
-                        request_id: "10"
+                        insertion_id: "10"
                       },
                       {
                         content_id: "5b4a6512326bd9777abfabcf",
-                        user_info: {user_id: "912", log_user_id: "91232"},
-                        timing: {client_log_timestamp: request_builder.timing[:client_log_timestamp]},
-                        insertion_id: "10",
                         position: 4,
-                        request_id: "10"
+                        insertion_id: "10"
                       }]
                     }
                   }],

--- a/spec/promoted/ruby/client/request_builder_spec.rb
+++ b/spec/promoted/ruby/client/request_builder_spec.rb
@@ -138,28 +138,23 @@ RSpec.describe Promoted::Ruby::Client::RequestBuilder do
                       insertion:
                       [{
                         content_id: "5b4a6512326bd9777abfabc34",
-                        # TODO - this looks broken.
-                        properties: []
+                        properties: {}
                       },
                       {
                         content_id: "5b4a6512326bd9777abfabea",
-                        # TODO - this looks broken.
-                        properties: []
+                        properties: {}
                       },
                       {
                         content_id: "5b4a6512326bd9777abfabcf",
-                        # TODO - this looks broken.
-                        properties: []
+                        properties: {}
                       },
                       {
                         content_id: "5b4a6512326bd9777abfabcf",
-                        # TODO - this looks broken.
-                        properties: []
+                        properties: {}
                       },
                       {
                         content_id: "5b4a6512326bd9777abfabcf",
-                        # TODO - this looks broken.
-                        properties: []
+                        properties: {}
                       }]
                     },
                     response: {

--- a/spec/promoted/ruby/client/validator_spec.rb
+++ b/spec/promoted/ruby/client/validator_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe Promoted::Ruby::Client::Validator do
             expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /request/)
         end
 
-        it "requires full_insertion" do
+        it "requires insertion" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input.delete :full_insertion
-            expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /full_insertion/)
+            dup_input[:request].delete :insertion
+            expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /insertion/)
         end
 
-        it "validates correct full_insertion type" do
+        it "validates correct insertion type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion] = {}
-            expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /full_insertion/)
+            dup_input[:request][:insertion] = {}
+            expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /insertion/)
         end
     end
 
@@ -128,121 +128,121 @@ RSpec.describe Promoted::Ruby::Client::Validator do
     context "insertion" do
         it "validates correct platform_id type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:platform_id] = 5
+            dup_input[:request][:insertion][0][:platform_id] = 5
             expect { @v.validate_metrics_request!(dup_input) }.not_to raise_error
         end
 
         it "validates incorrect platform_id type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:platform_id] = "5"
+            dup_input[:request][:insertion][0][:platform_id] = "5"
             expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /platform_id/)
         end
        
         it "validates correct insertion_id type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:insertion_id] = "5"
+            dup_input[:request][:insertion][0][:insertion_id] = "5"
             expect { @v.validate_metrics_request!(dup_input) }.not_to raise_error
         end
 
         it "validates incorrect insertion_id type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:insertion_id] = 5
+            dup_input[:request][:insertion][0][:insertion_id] = 5
             expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /insertion_id/)
         end
        
         it "validates correct request_id type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:request_id] = "5"
+            dup_input[:request][:insertion][0][:request_id] = "5"
             expect { @v.validate_metrics_request!(dup_input) }.not_to raise_error
         end
 
         it "validates incorrect request_id type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:request_id] = 5
+            dup_input[:request][:insertion][0][:request_id] = 5
             expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /request_id/)
         end
        
         it "validates correct view_id type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:view_id] = "5"
+            dup_input[:request][:insertion][0][:view_id] = "5"
             expect { @v.validate_metrics_request!(dup_input) }.not_to raise_error
         end
 
         it "validates incorrect view_id type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:view_id] = 5
+            dup_input[:request][:insertion][0][:view_id] = 5
             expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /view_id/)
         end
        
         it "validates correct session_id type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:session_id] = "5"
+            dup_input[:request][:insertion][0][:session_id] = "5"
             expect { @v.validate_metrics_request!(dup_input) }.not_to raise_error
         end
 
         it "validates incorrect session_id type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:session_id] = 5
+            dup_input[:request][:insertion][0][:session_id] = 5
             expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /session_id/)
         end
        
         it "validates correct content_id type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:content_id] = "5"
+            dup_input[:request][:insertion][0][:content_id] = "5"
             expect { @v.validate_metrics_request!(dup_input) }.not_to raise_error
         end
 
         it "validates incorrect content_id type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:content_id] = 5
+            dup_input[:request][:insertion][0][:content_id] = 5
             expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /content_id/)
         end
        
         it "validates correct position type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:position] = 5
+            dup_input[:request][:insertion][0][:position] = 5
             expect { @v.validate_metrics_request!(dup_input) }.not_to raise_error
         end
 
         it "validates incorrect position type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:position] = "5"
+            dup_input[:request][:insertion][0][:position] = "5"
             expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /position/)
         end
        
         it "validates correct delivery_score type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:delivery_score] = 5
+            dup_input[:request][:insertion][0][:delivery_score] = 5
             expect { @v.validate_metrics_request!(dup_input) }.not_to raise_error
         end
 
         it "validates incorrect delivery_score type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:delivery_score] = "5"
+            dup_input[:request][:insertion][0][:delivery_score] = "5"
             expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /delivery_score/)
         end       
        
         it "validates correct retrieval_rank type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:retrieval_rank] = 5
+            dup_input[:request][:insertion][0][:retrieval_rank] = 5
             expect { @v.validate_metrics_request!(dup_input) }.not_to raise_error
         end
 
         it "validates incorrect retrieval_rank type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:retrieval_rank] = "5"
+            dup_input[:request][:insertion][0][:retrieval_rank] = "5"
             expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /retrieval_rank/)
         end       
        
         it "validates correct retrieval_score type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:retrieval_score] = 5.2
+            dup_input[:request][:insertion][0][:retrieval_score] = 5.2
             expect { @v.validate_metrics_request!(dup_input) }.not_to raise_error
         end
 
         it "validates incorrect retrieval_score type" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion][0][:retrieval_score] = "5.2"
+            dup_input[:request][:insertion][0][:retrieval_score] = "5.2"
             expect { @v.validate_metrics_request!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /retrieval_score/)
         end       
     end
@@ -258,19 +258,12 @@ RSpec.describe Promoted::Ruby::Client::Validator do
             expect { @v.check_that_log_ids_not_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /requestId should not be set/)
         end
     
-        it "should raise error for request_id set in full_insertion" do
+        it "should raise error for request_id set in insertion" do
             dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:full_insertion].first[:request_id] = SecureRandom.uuid
+            dup_input[:request][:insertion].first[:request_id] = SecureRandom.uuid
             expect { @v.check_that_log_ids_not_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /Insertion.requestId should not be set/)
         end
-    
-        it "should raise insertion_id error for insertion" do
-            dup_input = Marshal.load(Marshal.dump(input))
-            dup_input[:insertion] = []
-            expect { @v.check_that_log_ids_not_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /Set full_insertion/)
-        end
     end
-
 
     context "check content ids are set" do
       it "should not raise any errors" do
@@ -279,13 +272,13 @@ RSpec.describe Promoted::Ruby::Client::Validator do
   
       it "should raise error for a blank insertion content id" do
           dup_input = Marshal.load(Marshal.dump(input))
-          dup_input[:full_insertion].first[:content_id] = ""
+          dup_input[:request][:insertion].first[:content_id] = ""
           expect { @v.check_that_content_ids_are_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /Insertion.contentId should be set/)
       end
   
       it "should raise error for a missing insertion content id" do
           dup_input = Marshal.load(Marshal.dump(input))
-          dup_input[:full_insertion].first.delete(:content_id)
+          dup_input[:request][:insertion].first.delete(:content_id)
           expect { @v.check_that_content_ids_are_set!(dup_input) }.to raise_error(Promoted::Ruby::Client::ValidationError, /Insertion.contentId should be set/)
       end
   end

--- a/spec/promoted/ruby/functional_test.rb
+++ b/spec/promoted/ruby/functional_test.rb
@@ -52,15 +52,17 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
                 :struct => {
                 :active => true
                 }
-            }
             },
-            :full_insertion => insertions
+            :insertion => insertions
+            },
+            :only_log => true
         }
 
         client = described_class.new(ENDPOINTS)
 
         # Build a log request
-        log_request = client.prepare_for_logging(metrics_request)    
+        client_response = client.deliver(metrics_request)
+        log_request = client_response[:log_request]
 
         client.send_log_request log_request
         
@@ -77,9 +79,9 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
                 :struct => {
                 :active => true
                 }
-            }
             },
-            :full_insertion => insertions,
+            :insertion => insertions,
+            },
             :only_log => false
         }
   

--- a/spec/shared/testdata.rb
+++ b/spec/shared/testdata.rb
@@ -13,30 +13,30 @@ SAMPLE_INPUT =  {
       struct: {
         query: {}
       }
-    }
-  },
-  full_insertion: [
-    {
-      content_id: "5b4a6512326bd9777abfabc34",
-      properties: []
     },
-    {
-      content_id: "5b4a6512326bd9777abfabea",
-      properties: []
-    },
-    {
-      content_id: "5b4a6512326bd9777abfabcf",
-      properties: []
-    },
-    {
-      content_id: "5b4a6512326bd9777abfabcf",
-      properties: []
-    },
-    {
-      content_id: "5b4a6512326bd9777abfabcf",
-      properties: []
-    }
-  ]
+    insertion: [
+      {
+        content_id: "5b4a6512326bd9777abfabc34",
+        properties: []
+      },
+      {
+        content_id: "5b4a6512326bd9777abfabea",
+        properties: []
+      },
+      {
+        content_id: "5b4a6512326bd9777abfabcf",
+        properties: []
+      },
+      {
+        content_id: "5b4a6512326bd9777abfabcf",
+        properties: []
+      },
+      {
+        content_id: "5b4a6512326bd9777abfabcf",
+        properties: []
+      }
+    ]
+  }
 }.freeze
 
 SAMPLE_INPUT_WITH_PROP =  {
@@ -54,90 +54,90 @@ SAMPLE_INPUT_WITH_PROP =  {
       struct: {
         query: {}
       }
-    }
-  },
-  full_insertion: [
-    {
-      content_id: "5b4a6512326bd9777abfabc34",
-      properties: {
-        struct: {
-          invites_required: 0,
-          should_discount_addons: false,
-          total_uses: 738,
-          is_archived: false,
-          non_combinable: false,
-          last_used_at: "2021-05-24T22:35:31.149Z",
-          last_purchase_at: "2021-05-24T22:35:31.214Z",
-          some_property_1: nil,
-          some_property_2: "some value..."
-        }
-      }
     },
-    {
-      content_id: "5b4a6512326bd9777abfabcf",
-      properties: {
-        struct: {
-          invites_required: 0,
-          should_discount_addons: false,
-          total_uses: 738,
-          is_archived: false,
-          non_combinable: false,
-          last_used_at: "2021-05-24T22:35:31.149Z",
-          last_purchase_at: "2021-05-24T22:35:31.214Z",
-          some_property_1: nil,
-          some_property_2: "some value..."
+    insertion: [
+      {
+        content_id: "5b4a6512326bd9777abfabc34",
+        properties: {
+          struct: {
+            invites_required: 0,
+            should_discount_addons: false,
+            total_uses: 738,
+            is_archived: false,
+            non_combinable: false,
+            last_used_at: "2021-05-24T22:35:31.149Z",
+            last_purchase_at: "2021-05-24T22:35:31.214Z",
+            some_property_1: nil,
+            some_property_2: "some value..."
+          }
+        }
+      },
+      {
+        content_id: "5b4a6512326bd9777abfabcf",
+        properties: {
+          struct: {
+            invites_required: 0,
+            should_discount_addons: false,
+            total_uses: 738,
+            is_archived: false,
+            non_combinable: false,
+            last_used_at: "2021-05-24T22:35:31.149Z",
+            last_purchase_at: "2021-05-24T22:35:31.214Z",
+            some_property_1: nil,
+            some_property_2: "some value..."
+          }
+        }
+      },
+      {
+        content_id: "5b4a6512326bd9777abfabcf",
+        properties: {
+          struct: {
+            invites_required: 0,
+            should_discount_addons: false,
+            total_uses: 738,
+            is_archived: false,
+            non_combinable: false,
+            last_used_at: "2021-05-24T22:35:31.149Z",
+            last_purchase_at: "2021-05-24T22:35:31.214Z",
+            some_property_1: nil,
+            some_property_2: "some value..."
+          }
+        }
+      },
+      {
+        content_id: "5b4a6512326bd9777abfabcf",
+        properties: {
+          struct: {
+            invites_required: 0,
+            should_discount_addons: false,
+            total_uses: 738,
+            is_archived: false,
+            non_combinable: false,
+            last_used_at: "2021-05-24T22:35:31.149Z",
+            last_purchase_at: "2021-05-24T22:35:31.214Z",
+            some_property_1: nil,
+            some_property_2: "some value..."
+          }
+        }
+      },
+      {
+        content_id: "5b4a6512326bd9777abfabcf",
+        properties: {
+          struct: {
+            invites_required: 0,
+            should_discount_addons: false,
+            total_uses: 738,
+            is_archived: false,
+            non_combinable: false,
+            last_used_at: "2021-05-24T22:35:31.149Z",
+            last_purchase_at: "2021-05-24T22:35:31.214Z",
+            some_property_1: nil,
+            some_property_2: "some value..."
+          }
         }
       }
-    },
-    {
-      content_id: "5b4a6512326bd9777abfabcf",
-      properties: {
-        struct: {
-          invites_required: 0,
-          should_discount_addons: false,
-          total_uses: 738,
-          is_archived: false,
-          non_combinable: false,
-          last_used_at: "2021-05-24T22:35:31.149Z",
-          last_purchase_at: "2021-05-24T22:35:31.214Z",
-          some_property_1: nil,
-          some_property_2: "some value..."
-        }
-      }
-    },
-    {
-      content_id: "5b4a6512326bd9777abfabcf",
-      properties: {
-        struct: {
-          invites_required: 0,
-          should_discount_addons: false,
-          total_uses: 738,
-          is_archived: false,
-          non_combinable: false,
-          last_used_at: "2021-05-24T22:35:31.149Z",
-          last_purchase_at: "2021-05-24T22:35:31.214Z",
-          some_property_1: nil,
-          some_property_2: "some value..."
-        }
-      }
-    },
-    {
-      content_id: "5b4a6512326bd9777abfabcf",
-      properties: {
-        struct: {
-          invites_required: 0,
-          should_discount_addons: false,
-          total_uses: 738,
-          is_archived: false,
-          non_combinable: false,
-          last_used_at: "2021-05-24T22:35:31.149Z",
-          last_purchase_at: "2021-05-24T22:35:31.214Z",
-          some_property_1: nil,
-          some_property_2: "some value..."
-        }
-      }
-    }
-  ]
+    ]
+  }
 }.freeze
 
 SAMPLE_INPUT_CAMEL = {
@@ -157,44 +157,44 @@ SAMPLE_INPUT_CAMEL = {
       "struct": {
         "query": "fakequery"
       }
-    }
-  },
-  "fullInsertion": [
-    {
-      "contentId": "product3",
-      "properties": {
-        "struct": {
-          "product": {
-            "id": "product3",
-            "title": "Product 3",
-            "url": "www.mymarket.com/p/3"
-          }
-        }
-      }
     },
-    {
-      "contentId": "product2",
-      "properties": {
-        "struct": {
-          "product": {
-            "id": "product2",
-            "title": "Product 2",
-            "url": "www.mymarket.com/p/2"
+    "insertion": [
+      {
+        "contentId": "product3",
+        "properties": {
+          "struct": {
+            "product": {
+              "id": "product3",
+              "title": "Product 3",
+              "url": "www.mymarket.com/p/3"
+            }
+          }
+        }
+      },
+      {
+        "contentId": "product2",
+        "properties": {
+          "struct": {
+            "product": {
+              "id": "product2",
+              "title": "Product 2",
+              "url": "www.mymarket.com/p/2"
+            }
+          }
+        }
+      },
+      {
+        "contentId": "product1",
+        "properties": {
+          "struct": {
+            "product": {
+              "id": "product1",
+              "title": "Product 1",
+              "url": "www.mymarket.com/p/1"
+            }
           }
         }
       }
-    },
-    {
-      "contentId": "product1",
-      "properties": {
-        "struct": {
-          "product": {
-            "id": "product1",
-            "title": "Product 1",
-            "url": "www.mymarket.com/p/1"
-          }
-        }
-      }
-    }
-  ]
+    ]
+  }
 }.freeze

--- a/spec/shared/testdata.rb
+++ b/spec/shared/testdata.rb
@@ -17,23 +17,23 @@ SAMPLE_INPUT =  {
     insertion: [
       {
         content_id: "5b4a6512326bd9777abfabc34",
-        properties: []
+        properties: {}
       },
       {
         content_id: "5b4a6512326bd9777abfabea",
-        properties: []
+        properties: {}
       },
       {
         content_id: "5b4a6512326bd9777abfabcf",
-        properties: []
+        properties: {}
       },
       {
         content_id: "5b4a6512326bd9777abfabcf",
-        properties: []
+        properties: {}
       },
       {
         content_id: "5b4a6512326bd9777abfabcf",
-        properties: []
+        properties: {}
       }
     ]
   }


### PR DESCRIPTION
Most of this PR is refactoring:
- Remove `prepare_for_logging`.  This reduces the number of calling paths and makes it more similar to promoted-ts-client.
- Remove compact functions.
- Move `full_insertion` to be `request.insertion`.
- Strips out a some unnecessary fields from the SDK DeliveryLog.

TESTING=modified existing specs