### PR TITLE
feat: add small validation for Delivery Response

### DIFF
--- a/lib/promoted/ruby/client.rb
+++ b/lib/promoted/ruby/client.rb
@@ -179,6 +179,7 @@ module Promoted
               delivery_request_params = delivery_request_builder.delivery_request_params  
               begin
                 response = send_request(delivery_request_params, @delivery_endpoint, @delivery_timeout_millis, @delivery_api_key, headers)
+                @validator.validate_response!(response)
               rescue  StandardError => err
                 # Currently we don't propagate errors to the SDK caller, but rather default to returning
                 # the request insertions.
@@ -346,6 +347,7 @@ module Promoted
           response = nil
           begin
             response = send_request(delivery_request_params, @delivery_endpoint, @delivery_timeout_millis, @delivery_api_key, headers, @async_shadow_traffic)
+            @validator.validate_response!(response)
           rescue StandardError => err
             @logger.warn("Shadow traffic call failed with #{err}") if @logger
             return

--- a/lib/promoted/ruby/client/validator.rb
+++ b/lib/promoted/ruby/client/validator.rb
@@ -116,6 +116,24 @@ module Promoted
                 end
             end
 
+            def validate_response!(res)
+                validate_fields!(
+                    res,
+                    "response",
+                    [
+                        {
+                            :name => :request_id,
+                            :required => true,
+                            :type => String
+                        }
+                    ]
+                )
+
+                if !res.key?(:insertion) then
+                    res[:insertion] = []
+                end
+            end
+
             # TODO - delete?
             def validate_metrics_request!(metrics_req)
                 validate_fields!(

--- a/spec/promoted/ruby/client/validator_spec.rb
+++ b/spec/promoted/ruby/client/validator_spec.rb
@@ -74,6 +74,22 @@ RSpec.describe Promoted::Ruby::Client::Validator do
         end
     end
 
+    context("response") do
+        it "validates requires request_id" do
+            response = {}.freeze
+            expect { @v.validate_response!(response) }.to raise_error(Promoted::Ruby::Client::ValidationError, /request_id/)
+        end
+
+        it "validates adds missing insertion field" do
+            response = {
+                :request_id => "reqid"
+            }
+            expect { @v.validate_response!(response) }.not_to raise_error
+            expected = []
+            expect(response[:insertion]).to eq expected
+        end
+    end
+
     context "user info" do
         it "validates correct user_id type" do
             dup_input = Marshal.load(Marshal.dump(input))

--- a/spec/promoted/ruby/client_spec.rb
+++ b/spec/promoted/ruby/client_spec.rb
@@ -448,7 +448,10 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       delivery_req = nil
       allow(client).to receive(:send_request) { |value|
         delivery_req = value
-        { :insertion => insertion }
+        {
+          :request_id => "reqid",
+          :insertion => insertion
+        }
       }
 
       deliver_resp = client.deliver @input
@@ -500,6 +503,7 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
     it "delivers with empty insertions, which is not an error" do
       client = described_class.new
       expect(client).to receive(:send_request).and_return({
+        :request_id => "reqid",
         :insertion => []
       })
       deliver_resp = client.deliver @input
@@ -516,6 +520,7 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
     it "delivers with nil insertions, which is not an error" do
       client = described_class.new
       expect(client).to receive(:send_request).and_return({
+        :request_id => "reqid",
         :insertion => nil
       })
       deliver_resp = client.deliver @input
@@ -772,6 +777,7 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       expect(client).to receive(:send_request) {|value|
         delivery_req = value
       }.and_return({
+        :request_id => "reqid",
         :insertion => insertion
       })
       deliver_resp = client.deliver @input
@@ -807,6 +813,7 @@ RSpec.describe Promoted::Ruby::Client::PromotedClient do
       expect(client).to receive(:send_request) {|value|
         delivery_req = value
       }.and_return({
+        :request_id => "reqid",
         :insertion => insertion
       })
       deliver_resp = client.deliver @input


### PR DESCRIPTION
fixes PRO-4312

Validates that Response contains request_id.

Also converts missing `:insertion` symbol to an empty array.

TESTING=unit tests