### PR TITLE
feat: release v2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    promoted-ruby-client (1.0.1)
+    promoted-ruby-client (2.0.0)
       concurrent-ruby (~> 1)
       faraday (>= 0.9.0)
       faraday_middleware (>= 0.9.0)

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Field Name | Type | Optional? | Description
 Output of ```deliver```, includes the insertions as well as a suitable ```LogRequest``` for forwarding to Metrics API.
 Field Name | Type | Optional? | Description
 ---------- | ---- | --------- | -----------
-```:insertion``` | [] of Insertion | No | The insertions, which are from Delivery API (when ```deliver``` was called, i.e. we weren't either only-log or part of an experiment) or the input insertions (when the other conditions don't hold).
+```:insertion``` | [] of Insertion | No | The paged insertions, which are from Delivery API (when ```deliver``` was called, i.e. we weren't either only-log or part of an experiment) or the input insertions (when the other conditions don't hold).
 ```:log_request``` | LogRequest | Yes | A message suitable for logging to Metrics API via ```send_log_request```. If the call to ```deliver``` was made (i.e. the request was not part of the CONTROL arm of an experiment or marked to only log), ```:log_request``` will not be set, as you can assume logging was performed on the server-side by Promoted.
 ```:client_request_id``` | String | Yes | Client-generated request id sent to Delivery API and may be useful for logging and debugging.
 ```:execution_server``` | one of 'API' or 'SDK' | Yes | Indicates if response insertions on a delivery request came from the API or the SDK.

--- a/dev.md
+++ b/dev.md
@@ -10,5 +10,5 @@ bundle exec rspec
 2. Get credentials for deployment from 1password.
 3. Modify `promoted-ruby-client.gemspec`'s push block.
 4. Run `gem build promoted-ruby-client.gemspec` to generate `gem`.
-5. Run (using new output) `gem push promoted-ruby-client-1.0.1.gem`
+5. Run (using new output) `gem push promoted-ruby-client-2.0.0.gem`
 6. Update README with new version.

--- a/lib/promoted/ruby/client/version.rb
+++ b/lib/promoted/ruby/client/version.rb
@@ -1,7 +1,7 @@
 module Promoted
   module Ruby
     module Client
-      VERSION = "1.0.1"
+      VERSION = "2.0.0"
       SERVER_VERSION = "rb." + VERSION
     end
   end

--- a/promoted-ruby-client.gemspec
+++ b/promoted-ruby-client.gemspec
@@ -14,19 +14,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/promotedai/promoted-ruby-client'
   spec.license       = 'MIT'
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    # Uncomment if you want to push to a custom host
-    # spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+  # Uncomment if you want to push to a custom host
+  # spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 
-    spec.metadata["homepage_uri"] = spec.homepage
-    spec.metadata["source_code_uri"] = "https://github.com/promotedai/promoted-ruby-client"
-    spec.metadata["changelog_uri"] = "https://github.com/promotedai/promoted-ruby-client/blob/master/CHANGELOG.md"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/promotedai/promoted-ruby-client"
+  spec.metadata["changelog_uri"] = "https://github.com/promotedai/promoted-ruby-client/blob/master/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
I'm bumping this because the delivery response has a breaking change (since we don't fill in insertion properties on the response).

TESTING=Existing unit tests. I made a manual delivery call from a Ruby client.